### PR TITLE
Include m3_env.h

### DIFF
--- a/Sources/CWasm3/include/m3_info.h
+++ b/Sources/CWasm3/include/m3_info.h
@@ -9,6 +9,7 @@
 #define m3_info_h
 
 #include "m3_compile.h"
+#include "m3_env.h"
 
 d_m3BeginExternC
 


### PR DESCRIPTION
Because IM3FuncType is defined in m3_env.h

- [x] Why did this work with Anthony?
    - Using Xcode 11.6 it works. It's unclear how `IM3FuncType` can be referenced in `m3_info.h` when it is defined in `m3_env.h` and yet the env header is never imported.
    - The current master will break when the new version of Xcode (12) is released